### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/architecture-diagram.yml
+++ b/.github/workflows/architecture-diagram.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,14 +55,14 @@ jobs:
             ghcr.io/bradms98/terravision:latest
 
       - name: Commit diagram changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403  # v5
         with:
           commit_message: "Update architecture diagram [skip ci]"
           file_pattern: "docs/architecture/*"
 
       - name: Comment on PR with diagram preview
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
       - name: Extract metadata
         if: startsWith(github.ref, 'refs/tags/v')
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ghcr.io/bradms98/terravision
           tags: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build (main branch — validate only)
         if: "!startsWith(github.ref, 'refs/tags/v')"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: false
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build and push (tagged release)
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: true

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -23,10 +23,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.14"
 
@@ -34,7 +34,7 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1
         with:
           version: 1.7.1
           virtualenvs-create: true
@@ -45,7 +45,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -54,7 +54,7 @@ jobs:
       #       Retrieve temporary AWS credentials
       #----------------------------------------------
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         timeout-minutes: 2
         with:
           role-to-assume: arn:aws:iam::166659698090:role/githubactions
@@ -70,7 +70,7 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --with test
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
       - name: Mock ssh file
         run :
           touch id_rsa.pub


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions in CI workflows to immutable commit SHAs instead of mutable version tags to prevent supply chain attacks
- Affects all 3 workflow files: `architecture-diagram.yml`, `build-image.yml`, `lint-and-test.yml`
- Retains version tag as an inline comment (e.g., `# v4`) for readability

## Test plan
- [ ] Verify CI workflows still execute correctly with SHA-pinned actions
- [ ] Confirm all 12 action references across 3 workflow files are pinned

Closes #6