### PR TITLE
fix: tailor preflight deps to output format and support OpenTofu

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1684,21 +1684,46 @@ def safe_remove_connection(
     return False
 
 
-def check_dependencies() -> None:
-    """Check if required command-line tools are available."""
-    dependencies = ["dot", "gvpr", "git", "terraform"]
+def check_dependencies(
+    output_format: Optional[str] = None, planfile: Optional[str] = None
+) -> None:
+    """Check if required command-line tools are available.
+
+    Dependencies are tailored to the run:
+    - ``git`` is always required (module downloads, etc.)
+    - ``dot``/``gvpr`` are only needed for graphviz-rendered formats
+      (png/svg/pdf/jpg/dot). The drawio renderer is pure Python.
+    - A Terraform-compatible binary (``terraform`` or ``tofu``) is only
+      required when we have to run ``terraform plan`` ourselves. When a
+      pre-generated ``--planfile`` is supplied we skip the binary entirely.
+    """
+    graphviz_formats = {"png", "svg", "pdf", "jpg", "jpeg", "dot"}
+    dependencies = ["git"]
+    if (output_format or "").lower() in graphviz_formats:
+        dependencies.extend(["dot", "gvpr"])
+    if not planfile:
+        dependencies.append(("terraform", "tofu"))
     bundle_dir = Path(__file__).parent
     import sys
 
     sys.path.append(str(bundle_dir))
-    for exe in dependencies:
-        location = shutil.which(exe) or os.path.isfile(exe)
+    for dep in dependencies:
+        candidates = (dep,) if isinstance(dep, str) else dep
+        location = next(
+            (
+                shutil.which(c) or (c if os.path.isfile(c) else None)
+                for c in candidates
+                if shutil.which(c) or os.path.isfile(c)
+            ),
+            None,
+        )
         if location:
-            click.echo(f"  {exe} command detected: {location}")
+            click.echo(f"  {candidates[0]} command detected: {location}")
         else:
+            label = " or ".join(candidates)
             click.echo(
                 click.style(
-                    f"\n  ERROR: {exe} command executable not detected in path. Please ensure you have installed all required dependencies first",
+                    f"\n  ERROR: {label} command executable not detected in path. Please ensure you have installed all required dependencies first",
                     fg="red",
                     bold=True,
                 )
@@ -1706,23 +1731,39 @@ def check_dependencies() -> None:
             exit()
 
 
-def check_terraform_version() -> None:
-    """Validate Terraform version is compatible."""
+def check_terraform_version(planfile: Optional[str] = None) -> None:
+    """Validate Terraform (or OpenTofu) version is compatible.
+
+    Skipped entirely when ``planfile`` is supplied — terravision doesn't
+    shell out to the IaC binary in that case.
+    """
+    if planfile:
+        return
+    binary = shutil.which("terraform") or shutil.which("tofu")
+    if not binary:
+        click.echo(
+            click.style(
+                "\n  ERROR: Neither terraform nor tofu found on PATH",
+                fg="red",
+                bold=True,
+            )
+        )
+        exit()
     try:
         result = subprocess.run(
-            ["terraform", "-v"], capture_output=True, text=True, check=True
+            [binary, "-v"], capture_output=True, text=True, check=True
         )
         version_output = result.stdout
 
         version_line = version_output.split("\n")[0]
-        print(f"  terraform version detected: {version_line}")
+        print(f"  {os.path.basename(binary)} version detected: {version_line}")
         tf_version = version_line.split(" ")[1].replace("v", "")
         version_major = tf_version.split(".")[0]
 
         if version_major != "1":
             click.echo(
                 click.style(
-                    f"\n  ERROR: Terraform Version '{tf_version}' is not supported. Please upgrade to >= v1.0.0",
+                    f"\n  ERROR: {os.path.basename(binary)} version '{tf_version}' is not supported. Please upgrade to >= v1.0.0",
                     fg="red",
                     bold=True,
                 )
@@ -1731,7 +1772,7 @@ def check_terraform_version() -> None:
     except (subprocess.CalledProcessError, IndexError, FileNotFoundError) as e:
         click.echo(
             click.style(
-                f"\n  ERROR: Failed to check Terraform version: {e}",
+                f"\n  ERROR: Failed to check {os.path.basename(binary)} version: {e}",
                 fg="red",
                 bold=True,
             )

--- a/terravision/terravision.py
+++ b/terravision/terravision.py
@@ -149,12 +149,16 @@ def compile_tfdata(
                 )
                 sys.exit(1)
             tfdata = {
-                "codepath": os.path.abspath(source) if os.path.isdir(source) else source,
+                "codepath": (
+                    os.path.abspath(source) if os.path.isdir(source) else source
+                ),
                 "workdir": os.getcwd(),
                 "plandata": dict(plandata),
                 "tf_resources_created": synthetic_changes,
             }
-            tfdata["plandata"]["prior_state"] = state_converter.state_to_prior_state(state_data)
+            tfdata["plandata"]["prior_state"] = state_converter.state_to_prior_state(
+                state_data
+            )
             tfdata = tfwrapper.setup_tfdata(tfdata)
             tfdata = graphmaker.infer_relationships_from_metadata(tfdata)
             tfdata = tfwrapper.add_vpc_implied_relations(tfdata)
@@ -170,6 +174,7 @@ def compile_tfdata(
                 else tfdata["codepath"]
             )
             import modules.fileparser as fileparser
+
             try:
                 tfdata = fileparser.read_tfsource(codepath_list, [], annotate, tfdata)
             except SystemExit:
@@ -185,7 +190,11 @@ def compile_tfdata(
                 tfdata.setdefault("module_source_dict", {})
                 tfdata.setdefault("all_variable", {})
                 # Detect provider from graphdict keys so detect_providers() is skipped
-                from modules.provider_detector import get_provider_for_resource, SUPPORTED_PROVIDERS
+                from modules.provider_detector import (
+                    get_provider_for_resource,
+                    SUPPORTED_PROVIDERS,
+                )
+
                 _prov_counts = {}
                 for _k in tfdata.get("graphdict", {}):
                     _p = get_provider_for_resource(_k)
@@ -213,10 +222,7 @@ def compile_tfdata(
 
     # State-only fallback: when plan has no resource_changes and a statefile
     # is provided, populate synthetic entries from the state file.
-    if (
-        not tfdata.get("tf_resources_created")
-        and statefile
-    ):
+    if not tfdata.get("tf_resources_created") and statefile:
         click.echo(
             click.style(
                 "\nNo resource changes in plan — using state file as fallback.\n",
@@ -239,7 +245,9 @@ def compile_tfdata(
         # Provide prior_state for inject_data_source_nodes
         if "plandata" not in tfdata:
             tfdata["plandata"] = {}
-        tfdata["plandata"]["prior_state"] = state_converter.state_to_prior_state(state_data)
+        tfdata["plandata"]["prior_state"] = state_converter.state_to_prior_state(
+            state_data
+        )
         # Re-run graph building since tf_resources_created was empty on first pass
         if tfdata.get("tfgraph"):
             tfdata = tfwrapper.tf_makegraph(tfdata, debug)
@@ -281,15 +289,24 @@ def compile_tfdata(
     return tfdata
 
 
-def preflight_check(aibackend: Optional[str] = None) -> None:
+def preflight_check(
+    aibackend: Optional[str] = None,
+    output_format: Optional[str] = None,
+    planfile: Optional[str] = None,
+) -> None:
     """Check required dependencies and Terraform version compatibility.
 
     Args:
         aibackend: AI backend to validate ('ollama' or 'bedrock')
+        output_format: Output format ('drawio', 'png', 'svg', ...). The drawio
+            renderer doesn't need graphviz (dot/gvpr), so those checks are
+            skipped when format is 'drawio'.
+        planfile: Path to pre-generated plan JSON. When supplied, the
+            terraform/tofu binary check is skipped entirely.
     """
     click.echo(click.style("\nPreflight check..", fg="white", bold=True))
-    helpers.check_dependencies()
-    helpers.check_terraform_version()
+    helpers.check_dependencies(output_format=output_format, planfile=planfile)
+    helpers.check_terraform_version(planfile=planfile)
 
     if aibackend:
         # Load default AWS config for preflight (endpoints are the same across providers)
@@ -435,7 +452,11 @@ def draw(
                 fg="yellow",
             )
         )
-    preflight_check(aibackend if not planfile else None)
+    preflight_check(
+        aibackend if not planfile else None,
+        output_format=format,
+        planfile=planfile,
+    )
     tfdata = compile_tfdata(
         source, varfile, workspace, debug, annotate, planfile, graphfile, statefile
     )
@@ -562,7 +583,10 @@ def graphdata(
                 fg="yellow",
             )
         )
-    preflight_check(aibackend if not planfile else None)
+    preflight_check(
+        aibackend if not planfile else None,
+        planfile=planfile,
+    )
     tfdata = compile_tfdata(
         source, varfile, workspace, debug, annotate, planfile, graphfile
     )


### PR DESCRIPTION
## Summary
- Preflight now requires `dot`/`gvpr` only for graphviz-rendered formats (png, svg, pdf, jpg, jpeg, dot) — drawio output no longer needs graphviz installed
- `check_terraform_version()` accepts `terraform` or `tofu` and is skipped entirely when a `--planfile` is supplied
- `preflight_check()` forwards `output_format` and `planfile` so checks key off actual run inputs
- Fixes the Scalr post-apply hook which runs on an OpenTofu runner with no graphviz

## Test plan
- [x] `pytest -m "not slow"` — 301 passed
- [ ] Next Scalr post-apply run should clear preflight on an OpenTofu-only runner and produce `/tmp/architecture.drawio`