### PR TITLE
fix(ci): pin Python to 3.13 so poetry install can resolve pydot

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       #----------------------------------------------
       #  -----  install & configure poetry  -----


### PR DESCRIPTION
## Summary
- The \`lint-and-test\` workflow explicitly pins \`python-version: \"3.14\"\` (line 30), which resolves to Python 3.14.x on hosted runners.
- \`poetry install\` fails there with \`pydot (^2.0.0) which doesn't match any versions, version solving failed\` because pydot 2.x doesn't yet publish a release compatible with Python 3.14.
- Dropping the pin to \`3.13\` unblocks CI immediately without touching dependency versions or the lock file. PR #28 and PR #29 both landed with this same workflow red; this should turn it green.

## What this does not fix
- The \`poetry.lock is not consistent with pyproject.toml\` warning is separate (stale lock vs. pyproject edits). Worth a follow-up \`poetry lock\` run, but not required to get CI green.
- If/when pydot publishes Python 3.14 wheels, we can bump the pin back to \`3.14\` (or just remove the pin and use the runner default) in a follow-up.

## Test plan
- [ ] \`lint-and-test\` workflow passes on this branch
- [ ] Post-merge, \`lint-and-test\` passes on \`main\`