### PR TITLE
feat(filter): env var, 'none' escape hatch, and default-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Output is written to `<repo>/docs/architecture/architecture.drawio` by default.
 | `TF_API_TOKEN` | Yes | | Scalr API token |
 | `SCALR_HOSTNAME` | Yes | | Scalr instance (e.g. `sunward.scalr.io`) |
 | `WORKSPACE_ID` | Yes | | Scalr workspace ID |
-| `DIAGRAM_FILTER` | No | `default` | Filter profile, or `none` to show all resources |
+| `DIAGRAM_FILTER` | No | `default` | Filter profile name (see [Filter Profiles](#filter-profiles)). Set to `none` to disable filtering entirely; unknown names fall back to `default` with a logged error. |
 | `OUTPUT_FORMAT` | No | `drawio` | `drawio`, `png`, or `both` |
 | `OUTPUT_PATH` | No | `docs/architecture` | Output directory relative to source |
 | `GH_TOKEN` | No | | GitHub token for cloning private modules |
@@ -242,10 +242,43 @@ terravision draw --source ./terraform --show
 | `--planfile`  | Pre-generated plan JSON file  | `plan.json`                |
 | `--graphfile` | Pre-generated graph DOT file  | `graph.dot`                |
 | `--statefile` | Terraform state JSON file     | `state.json`               |
-| `--filter`    | Filter profile from `filters/` dir | `default`, `network`  |
+| `--filter`    | Filter profile from `filters/` dir (see [Filter Profiles](#filter-profiles)) | `default`, `network`, `none` |
 | `--simplified` | Simplified high-level view   | (flag)                     |
 | `--show`      | Open diagram after generation | (flag)                     |
 | `--debug`     | Enable debug output           | (flag)                     |
+
+### Filter Profiles
+
+TerraVision reads YAML filter files from the `filters/` directory to decide which resource types to drop from the diagram (both from the logical graph and at render time). This keeps the diagram focused on architecturally interesting resources instead of IAM/CloudWatch/SSM plumbing.
+
+**Selecting a filter:**
+
+```sh
+# CLI flag
+terravision draw --source ./terraform --filter network
+
+# Environment variable (same behavior, useful for Scalr hooks, Docker, CI)
+TERRAVISION_FILTER=network terravision draw --source ./terraform
+```
+
+The flag takes precedence over the env var when both are set.
+
+**Built-in profiles** (in `filters/`):
+
+| Name | Purpose |
+|---|---|
+| `default` | Drops noisy plumbing (IAM, CloudWatch, KMS, SSM, route tables, flow logs, etc.). Used by the renderer when no `--filter` is supplied. |
+| `network` | Keeps VPCs, subnets, gateways, and networking resources; hides IAM, monitoring, and keys. |
+
+Add your own by dropping a `<name>.yaml` file into `filters/` with an `exclude:` list of resource types.
+
+**Special values:**
+
+| Value | Behavior |
+|---|---|
+| _(omitted / empty)_ | Graph is unfiltered; the renderer still applies `filters/default.yaml` so unfiltered output isn't overwhelming. |
+| `none` | Fully disables filtering at both the graph and render layers — every resource is shown. |
+| _unknown name_ | Logs a red `ERROR:` message listing available filters and the fix, then falls back to `default` for the rest of the run. Non-fatal. |
 
 ### Supported Output Formats
 
@@ -397,6 +430,7 @@ curl -fsSL https://raw.githubusercontent.com/bradms98/terravision/main/hooks/sca
 | Variable | Default | Description |
 |---|---|---|
 | `GH_TOKEN` | unset | GitHub PAT; only needed if you fork this repo and make it private |
+| `TERRAVISION_FILTER` | unset | Filter profile name (e.g. `network`, `security`). Loads `filters/<name>.yaml` from the terravision package; falls back to `filters/default.yaml` if the named file is missing (error is logged). Set to `none` to disable filtering entirely. Unset = no filter applied. |
 | `LOGGING` | `INFO` | `NONE` (errors only), `INFO` (progress banners), or `DEBUG` (full tool output + HTTP bodies) |
 
 **What the hook does on each apply:**

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 # OUTPUT_FORMAT    - drawio (default), png, or both
 # OUTPUT_PATH      - output directory (default: docs/architecture)
 # RUN_STATUS_FILTER - applied (post-apply) or planned (PR speculative)
-# DIAGRAM_FILTER   - terravision --filter value (default: default, set to "none" to disable)
+# DIAGRAM_FILTER   - terravision --filter value (default: default). Unknown names
+#                    fall back to the default filter with a logged error; set to
+#                    "none" to disable filtering entirely at graph and render layers.
 # GH_TOKEN         - GitHub token for cloning private modules (also accepts GITHUB_TOKEN or GIT_TOKEN)
 
 # Scalr CLI reads SCALR_TOKEN and SCALR_HOSTNAME from env vars directly

--- a/docs/scalr-hook-integration.md
+++ b/docs/scalr-hook-integration.md
@@ -38,6 +38,13 @@ Terravision's draw.io rendering path is pure Python (XML generation via `Element
 | `CONF_TOKEN` | Workspace or Environment | Yes | Atlassian API token |
 | `GH_TOKEN` | Workspace or Environment | Yes | GitHub token (only needed if Terravision repo goes private) |
 
+### Optional Scalr Variables
+
+| Variable | Level | Default | Description |
+|---|---|---|---|
+| `TERRAVISION_FILTER` | Workspace or Environment | unset | Filter profile name (e.g. `network`). Loads `filters/<name>.yaml` from the Terravision package; unknown names fall back to `default` with a logged error; `none` disables filtering at both the graph and render layers. See the main [README → Filter Profiles](../README.md#filter-profiles). |
+| `LOGGING` | Workspace or Environment | `INFO` | `NONE` (errors only), `INFO` (progress banners), or `DEBUG` (verbose tool output + HTTP bodies). |
+
 ### Auto-Injected Scalr Variables (no setup needed)
 
 | Variable | Description |

--- a/hooks/scalr-post-apply.sh
+++ b/hooks/scalr-post-apply.sh
@@ -16,13 +16,19 @@ set -euo pipefail
 #   CONFLUENCE_SPACE_KEY      — Confluence space key for new pages
 #
 # Optional:
-#   GH_TOKEN  — GitHub token (if terravision repo goes private)
-#   LOGGING   — NONE | INFO (default) | DEBUG
-#               NONE:  errors only
-#               INFO:  progress banners + status
-#               DEBUG: INFO + verbose tool output,
-#                      HTTP codes/bodies, plan/state info
-#               tqdm progress bars are always suppressed.
+#   GH_TOKEN            — GitHub token (if terravision repo goes private)
+#   TERRAVISION_FILTER  — filter profile name (e.g. "network", "security").
+#                         Loads filters/<name>.yaml from the terravision
+#                         package. Falls back to filters/default.yaml if the
+#                         named file is missing (error is logged). Set to
+#                         "none" to disable filtering entirely. Unset = no
+#                         filter applied.
+#   LOGGING             — NONE | INFO (default) | DEBUG
+#                         NONE:  errors only
+#                         INFO:  progress banners + status
+#                         DEBUG: INFO + verbose tool output,
+#                                HTTP codes/bodies, plan/state info
+#                         tqdm progress bars are always suppressed.
 
 CONF_BASE_URL="${CONFLUENCE_BASE_URL:-}"
 PARENT_PAGE_ID="${CONFLUENCE_PARENT_PAGE_ID:-}"

--- a/modules/drawio_renderer.py
+++ b/modules/drawio_renderer.py
@@ -467,21 +467,27 @@ def render_drawio(tfdata, outfile, source, layout):
                 vpc_prefix_identities[pfx] = ids
                 vpc_all_names |= ids
 
-    # Resource types to hide (loaded from filters/default.yaml)
-    HIDE_TYPES = set()
-    try:
-        import yaml
-        from pathlib import Path
+    # Resource types to hide at render time. Prefer the set published by the
+    # graph-level filter (graphmaker.filter_graphdict) or the --filter=none
+    # short-circuit; otherwise fall back to filters/default.yaml so an
+    # unfiltered invocation still drops the noisy defaults.
+    if "hide_types" in tfdata:
+        HIDE_TYPES = set(tfdata["hide_types"])
+    else:
+        HIDE_TYPES = set()
+        try:
+            import yaml
+            from pathlib import Path
 
-        _default_filter = (
-            Path(__file__).resolve().parent.parent / "filters" / "default.yaml"
-        )
-        if _default_filter.exists():
-            with open(_default_filter) as _f:
-                _filter_data = yaml.safe_load(_f)
-            HIDE_TYPES = set(_filter_data.get("exclude", []))
-    except Exception:
-        pass
+            _default_filter = (
+                Path(__file__).resolve().parent.parent / "filters" / "default.yaml"
+            )
+            if _default_filter.exists():
+                with open(_default_filter) as _f:
+                    _filter_data = yaml.safe_load(_f)
+                HIDE_TYPES = set(_filter_data.get("exclude", []))
+        except Exception:
+            pass
 
     def _targets_different_vpc(resource_key, current_vpc_identities):
         """Check if a resource key's bracket content references a different VPC.

--- a/modules/graphmaker.py
+++ b/modules/graphmaker.py
@@ -2832,42 +2832,75 @@ def filter_graphdict(tfdata: Dict[str, Any], filter_name: str) -> None:
         Path(__file__).parent.parent / "filters",
     ]
 
-    filter_path = None
-    for search_dir in search_paths:
-        candidate = search_dir / f"{filter_name}.yaml"
-        if candidate.exists():
-            filter_path = candidate
-            break
+    def _find_filter(name: str):
+        for search_dir in search_paths:
+            candidate = search_dir / f"{name}.yaml"
+            if candidate.exists():
+                return candidate
+        return None
 
-    if filter_path is None:
-        click.echo(
-            click.style(
-                f"\nERROR: Filter '{filter_name}' not found.",
-                fg="red",
-            )
-        )
-        # List available filters from all search paths
+    def _list_available() -> list:
         available = set()
         for search_dir in search_paths:
             if search_dir.exists():
                 available.update(f.stem for f in search_dir.glob("*.yaml"))
+        return sorted(available)
+
+    filter_path = _find_filter(filter_name)
+    resolved_name = filter_name
+
+    if filter_path is None and filter_name != "default":
+        click.echo(
+            click.style(
+                f"\nERROR: Filter '{filter_name}' not found — running with 'default' filter instead.",
+                fg="red",
+            )
+        )
+        available = _list_available()
         if available:
-            click.echo(f"Available filters: {', '.join(sorted(available))}")
+            click.echo(f"  Available filters: {', '.join(available)}")
+        click.echo(
+            "  Set --filter=<name> or TERRAVISION_FILTER=<name> to one of the above, "
+            "or 'none' to disable filtering entirely."
+        )
+        filter_path = _find_filter("default")
+        resolved_name = "default"
+
+    if filter_path is None:
+        click.echo(
+            click.style(
+                f"\nERROR: Filter '{filter_name}' not found and no default filter available.",
+                fg="red",
+            )
+        )
+        available = _list_available()
+        if available:
+            click.echo(f"  Available filters: {', '.join(available)}")
         else:
             click.echo(
-                "No filter files found. Create YAML files in a filters/ directory."
+                "  No filter files found. Create YAML files in a filters/ directory."
             )
+        click.echo(
+            "  Set --filter=<name> or TERRAVISION_FILTER=<name> to one of the above, "
+            "or 'none' to disable filtering entirely."
+        )
         return
 
     with open(filter_path, "r") as f:
         filter_config = yaml.safe_load(f)
 
     exclude_types = set(filter_config.get("exclude", []))
+
+    # Publish the resolved exclude list so the drawio renderer hides the same
+    # types at render time. Without this, the renderer would fall back to
+    # filters/default.yaml regardless of --filter choice.
+    tfdata["hide_types"] = exclude_types
+
     if not exclude_types:
-        click.echo(f"Filter '{filter_name}' has no exclude list, skipping.")
+        click.echo(f"Filter '{resolved_name}' has no exclude list, skipping.")
         return
 
-    click.echo(f"\nApplying filter: {filter_name}")
+    click.echo(f"\nApplying filter: {resolved_name}")
     click.echo(f"  Excluding {len(exclude_types)} resource type(s)")
 
     graphdict = tfdata.get("graphdict", {})

--- a/terravision/terravision.py
+++ b/terravision/terravision.py
@@ -372,7 +372,8 @@ def cli() -> None:
     "--filter",
     "filter_name",
     default="",
-    help="Filter profile name from filters/ directory (e.g. network, security)",
+    envvar="TERRAVISION_FILTER",
+    help="Filter profile name from filters/ directory (e.g. network, security). Use 'none' to disable filtering. Falls back to filters/default.yaml if the named file is missing. Env: TERRAVISION_FILTER",
 )
 @click.option(
     "--aibackend",
@@ -469,10 +470,15 @@ def draw(
         graphmaker.simplify_graphdict(tfdata)
         _print_graph_debug(tfdata["graphdict"], "Simplified graphviz dictionary")
 
-    # Apply filter profile to exclude resource types
-    if filter_name:
+    # Apply filter profile to exclude resource types.
+    # TERRAVISION_FILTER=none (case-insensitive) disables filtering entirely,
+    # including the renderer's own render-time hiding.
+    if filter_name and filter_name.lower() != "none":
         graphmaker.filter_graphdict(tfdata, filter_name)
         _print_graph_debug(tfdata["graphdict"], "Filtered graphviz dictionary")
+    elif filter_name and filter_name.lower() == "none":
+        click.echo("Filter disabled (TERRAVISION_FILTER=none)")
+        tfdata["hide_types"] = set()
 
     # Add provider suffix to output filename for non-AWS providers
     final_outfile = outfile
@@ -516,7 +522,8 @@ def draw(
     "--filter",
     "filter_name",
     default="",
-    help="Filter profile name from filters/ directory (e.g. network, security)",
+    envvar="TERRAVISION_FILTER",
+    help="Filter profile name from filters/ directory (e.g. network, security). Use 'none' to disable filtering. Falls back to filters/default.yaml if the named file is missing. Env: TERRAVISION_FILTER",
 )
 @click.option(
     "--simplified",
@@ -595,8 +602,11 @@ def graphdata(
         tfdata = llm.refine_with_llm(tfdata, aibackend, debug)
     if simplified:
         graphmaker.simplify_graphdict(tfdata)
-    if filter_name:
+    if filter_name and filter_name.lower() != "none":
         graphmaker.filter_graphdict(tfdata, filter_name)
+    elif filter_name and filter_name.lower() == "none":
+        click.echo("Filter disabled (TERRAVISION_FILTER=none)")
+        tfdata["hide_types"] = set()
     click.echo(click.style("\nFinal Output JSON Dictionary :", fg="white", bold=True))
     unique = helpers.unique_services(tfdata["graphdict"])
     click.echo(


### PR DESCRIPTION
## Summary

Reworks the filter system so the Scalr post-apply hook (and any other env-driven invocation) can select a filter profile without flag plumbing, adds a `none` escape hatch that actually disables filtering at both layers, and makes missing filter names a non-fatal error that falls back to `default`.

- `TERRAVISION_FILTER` env var (via Click `envvar=` on `--filter`) — no bash changes needed in `hooks/scalr-post-apply.sh`.
- `TERRAVISION_FILTER=none` fully disables filtering at both the graph level (`graphmaker.filter_graphdict`) and the renderer level (`drawio_renderer.HIDE_TYPES`). Previously the renderer hardcoded `filters/default.yaml` regardless of `--filter`.
- Unknown filter names log a red `ERROR:` listing the available filters and the fix, then fall back to `filters/default.yaml` for the rest of the run instead of silently skipping.
- The renderer now honors the resolved filter — `--filter=network` actually drops network's excluded types at render time, not just from the logical graph.
- Unfiltered invocations (`--filter` unset, no env var) still apply `default.yaml` at render time, preserving prior behavior.

## Docs

- New `### Filter Profiles` section in README covering CLI flag, env var, built-in profiles, special values, and adding custom filters.
- Refreshed `--filter` row in the CLI options table, the Docker `DIAGRAM_FILTER` row, and the `--filter` CLI `--help` text.
- Added an "Optional Scalr Variables" table to `docs/scalr-hook-integration.md` covering `TERRAVISION_FILTER` and `LOGGING`.
- Updated `hooks/scalr-post-apply.sh` and `docker/entrypoint.sh` header comments.

## Test plan

Ad-hoc verified locally against `~/git/aws_prod_network` cached `plan.json` + `graph.dot` for five cases:

| Case | Console output | Output bytes |
|---|---|---|
| unset | (no filter lines) | 40,707 |
| `default` | `Applying filter: default` — removed 54 of 39 types | 36,138 |
| `network` | `Applying filter: network` — removed 33 of 18 types | 58,556 |
| `bogus` | `ERROR: Filter 'bogus' not found — running with 'default' filter instead.` + available filters + instructions | 36,138 (matches `default`) |
| `none` | `Filter disabled (TERRAVISION_FILTER=none)` | 86,051 (largest — nothing hidden) |

- [x] Env var is picked up by `--filter` (`terravision draw --help` shows `Env: TERRAVISION_FILTER`)
- [x] `none` produces strictly larger output than `unset` (renderer hides nothing)
- [x] `network` exclude list is actually honored at render time (different bytes from `default`)
- [x] Bogus name produces red ERROR + available-filter list + usage hint, then falls back to default
- [x] Python syntax check passes on `modules/graphmaker.py`, `modules/drawio_renderer.py`, `terravision/terravision.py`
- [x] `bash -n` passes on `hooks/scalr-post-apply.sh` and `docker/entrypoint.sh`