### PR TITLE
fix(ci): bump Poetry to 2.2.1 and regenerate lockfile with pydot

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1
         with:
-          version: 1.7.1
+          version: 2.2.1
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -257,7 +257,7 @@ version = "1.8.19"
 description = "An implementation of the Debug Adapter Protocol for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "debugpy-1.8.19-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:fce6da15d73be5935b4438435c53adb512326a3e11e4f90793ea87cd9f018254"},
     {file = "debugpy-1.8.19-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:e24b1652a1df1ab04d81e7ead446a91c226de704ff5dde6bd0a0dbaab07aa3f2"},
@@ -361,23 +361,6 @@ files = [
 dev = ["flake8", "pep8-naming", "tox (>=3)", "twine", "wheel"]
 docs = ["sphinx (>=5)", "sphinx-autodoc-typehints", "sphinx-rtd-theme"]
 test = ["coverage", "mock (>=4)", "pytest (>=7)", "pytest-cov", "pytest-mock (>=3)"]
-
-[[package]]
-name = "graphviz2drawio"
-version = "1.1.0"
-description = "Convert graphviz (dot) files to draw.io / lucid (mxGraph) format. Beautiful and editable graphs in your favorite editor."
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "graphviz2drawio-1.1.0-py3-none-any.whl", hash = "sha256:e3b039830b39ad380d335fdca2649b77c1700064f6b8d30fdc62f04de8270e04"},
-    {file = "graphviz2drawio-1.1.0.tar.gz", hash = "sha256:8758b9eefbac5d8c03a0358c0158845235c9c3caa99887f0f6026cfecc2895f2"},
-]
-
-[package.dependencies]
-puremagic = "*"
-pygraphviz = "*"
-"svg.path" = "*"
 
 [[package]]
 name = "h11"
@@ -641,18 +624,6 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
-name = "puremagic"
-version = "1.30"
-description = "Pure python implementation of magic file detection"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "puremagic-1.30-py3-none-any.whl", hash = "sha256:5eeeb2dd86f335b9cfe8e205346612197af3500c6872dffebf26929f56e9d3c1"},
-    {file = "puremagic-1.30.tar.gz", hash = "sha256:f9ff7ac157d54e9cf3bff1addfd97233548e75e685282d84ae11e7ffee1614c9"},
-]
-
-[[package]]
 name = "pydantic"
 version = "2.12.5"
 description = "Data validation using Python type hints"
@@ -809,15 +780,39 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
-name = "pygraphviz"
-version = "1.14"
-description = "Python interface to Graphviz"
+name = "pydot"
+version = "2.0.0"
+description = "Python interface to Graphviz's Dot"
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "pygraphviz-1.14.tar.gz", hash = "sha256:c10df02377f4e39b00ae17c862f4ee7e5767317f1c6b2dfd04cea6acc7fc2bea"},
+    {file = "pydot-2.0.0-py3-none-any.whl", hash = "sha256:408a47913ea7bd5d2d34b274144880c1310c4aee901f353cf21fe2e526a4ea28"},
+    {file = "pydot-2.0.0.tar.gz", hash = "sha256:60246af215123fa062f21cd791be67dda23a6f280df09f68919e637a1e4f3235"},
 ]
+
+[package.dependencies]
+pyparsing = ">=3"
+
+[package.extras]
+dev = ["black", "chardet"]
+release = ["zest.releaser[recommended]"]
+tests = ["black", "chardet", "tox"]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -973,21 +968,6 @@ files = [
 ]
 
 [[package]]
-name = "svg-path"
-version = "7.0"
-description = "SVG path objects and parser"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "svg_path-7.0-py2.py3-none-any.whl", hash = "sha256:447cb1e16a95acea2dd867fe737fa99cb75d587b4fc64dbee709a8dd6891ad9c"},
-    {file = "svg_path-7.0.tar.gz", hash = "sha256:9037486957cb1dcf4375ef42206499a47c111b8ffcbac6e3e55f9d079d875bb0"},
-]
-
-[package.extras]
-test = ["Pillow", "black", "check-manifest", "flake8", "mypy", "pyroma", "pytest", "pytest-cov", "zest.releaser[recommended]"]
-
-[[package]]
 name = "tomli"
 version = "2.3.0"
 description = "A lil' TOML parser"
@@ -1129,4 +1109,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "12e9a1c89247d9d257e0d3aa5b1ce3b514a6b52b448ace2d2e2c599f5c0cdf0d"
+content-hash = "bea05444f1d9dd774d206fd9034737bb38849790ea26ddba1660de697d3c20bd"


### PR DESCRIPTION
## Summary

Fixes two stacked problems that have been failing the `lint-and-test` workflow since the pydot migration (`a428dd1`):

1. **Poetry version mismatch.** `lint-and-test.yml` pinned Poetry to `1.7.1`, but `poetry.lock`'s header says it was generated by Poetry `2.2.1`. The old Poetry rejected the newer lockfile format and fell back to a fresh resolve.
2. **Stale lockfile.** Commit `a428dd1` added `pydot = "^2.0.0"` to `pyproject.toml` but never regenerated `poetry.lock` — grep'ing the pre-change lockfile for `name = "pydot"` returned nothing. Poetry 1.7.1's fresh-resolve path then failed with `pydot (^2.0.0) doesn't match any versions`.

Blocks PR #32 (filter env var work) and any future PR from passing CI.

## Changes

- `.github/workflows/lint-and-test.yml` — bump `snok/install-poetry` version from `1.7.1` to `2.2.1` to match the lockfile generator.
- `poetry.lock` — regenerated with Poetry 2.2.1. Net diff +31/-51 lines; `pydot 2.0.0` now has a proper entry.

`pyproject.toml` has pre-existing warnings about duplicated `[project]` and `[tool.poetry]` keys — out of scope for this PR.

## Test plan

- [x] `poetry lock` succeeds locally with Poetry 2.2.1
- [x] `grep 'name = "pydot"' poetry.lock` now returns a match (2.0.0)
- [x] `poetry check` returns no errors (warnings only, pre-existing)
- [ ] CI passes on this branch (will verify after push)